### PR TITLE
Add support for configuring OAuth redirect parameter key

### DIFF
--- a/autoform/field_oauth.go
+++ b/autoform/field_oauth.go
@@ -41,7 +41,7 @@ func NewOAuthField(authURL string, tokenURL *string, scopes []string) *OAuthFiel
 		AuthURL:          &authURL,
 		TokenURL:         tokenURL,
 		Scope:            scopes,
-		RedirectParamKey: "redirect_uri",
+		RedirectParamKey: "redirect_uri", 
 	}
 
 	return c


### PR DESCRIPTION
Introduced the `RedirectParamKey` field to the OAuth schema, enabling customization of the redirect URI query parameter name. Updated `OAuthField` with a new setter method `SetRedirectQueryParamKey` to allow flexible configuration. Ensured default behavior is preserved where this field is not set.